### PR TITLE
Add maxAuthLifetime configuration to SamlConfig

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,10 @@ flag above.)
 keystore (needs to be the same as the password provided throguh the `keystore`
 flag above.)
 
+**saml.maxAuthLifetime**: (Optional) Max Authentication Lifetime configuration.
+
+Default is `86400`
+
 **saml.displayNameAttr**: Gerrit will look for an attribute with this name in
 the assertion to find a display name for the user. If the attribute is not
 found, the NameId from the SAML assertion is used instead.

--- a/build.sbt
+++ b/build.sbt
@@ -1,14 +1,14 @@
 name := "gerrit-saml-plugin"
 
-val GerritVersion = "2.12"
+val GerritVersion = "2.13"
 
-version := GerritVersion + "-1"
+version := GerritVersion + "-6"
 
 javacOptions ++= Seq("-source", "1.7", "-target", "1.7")
 
 libraryDependencies += ("com.google.gerrit" % "gerrit-plugin-api" % GerritVersion % "provided")
 
-libraryDependencies += "org.pac4j" % "pac4j-saml" % "1.8.0-RC1"
+libraryDependencies += "org.pac4j" % "pac4j-saml" % "2.0.0-RC1"
 
 libraryDependencies ~= { _ map {
   case m => m
@@ -35,7 +35,9 @@ assemblyMergeStrategy in assembly := {
   case PathList("META-INF", "INDEX.LIST") => MergeStrategy.discard
   case PathList("META-INF", "MANIFEST.MF") => MergeStrategy.discard
   case PathList("META-INF", "NOTICE") => MergeStrategy.discard
+  case PathList("META-INF", "NOTICE.txt") => MergeStrategy.discard
   case PathList("META-INF", "LICENSE") => MergeStrategy.concat
+  case PathList("META-INF", "LICENSE.txt") => MergeStrategy.concat
   // Trick is here: get all the initializers concatenated...
   case PathList("META-INF", "services", "org.opensaml.core.config.Initializer") => MergeStrategy.concat
   case PathList("schema", v) if v.endsWith(".xsd") => MergeStrategy.first

--- a/src/main/java/com/thesamet/gerrit/plugins/saml/SamlConfig.java
+++ b/src/main/java/com/thesamet/gerrit/plugins/saml/SamlConfig.java
@@ -25,6 +25,7 @@ import org.eclipse.jgit.lib.Config;
  */
 @Singleton
 public class SamlConfig {
+
   private final String metadataPath;
   private final String keystorePath;
   private final String privateKeyPassword;
@@ -32,7 +33,7 @@ public class SamlConfig {
   private final String displayNameAttr;
   private final String userNameAttr;
   private final String emailAddressAttr;
-  private final String maxAuthLifetimeAttr;
+  private final int maxAuthLifetimeAttr;
   private final int maxAuthLifetimeDefault = 24 * 60 * 60; // 24h;
 
   @Inject
@@ -46,8 +47,7 @@ public class SamlConfig {
     userNameAttr = getGetStringWithDefault(cfg, "userNameAttr", "UserName");
     emailAddressAttr =
         getGetStringWithDefault(cfg, "emailAddressAttr", "EmailAddress");
-    maxAuthLifetimeAttr =
-            getGetStringWithDefault(cfg, "maxAuthLifetime", Integer.toString(maxAuthLifetimeDefault));
+    maxAuthLifetimeAttr = cfg.getInt("saml", null, maxAuthLifetimeDefault);
   }
 
   public String getMetadataPath() {
@@ -78,17 +78,8 @@ public class SamlConfig {
     return emailAddressAttr;
   }
 
-  public String getMaxAuthLifetimeAttr() { return maxAuthLifetimeAttr; }
-
-  public int getMaxAuthLifetime() {
-    int maxLifetime;
-    try {
-      maxLifetime = Integer.parseInt(getMaxAuthLifetimeAttr());
-    } catch (NumberFormatException nfe) {
-      SamlWebFilter.logError("Error reading \"maxAuthLifetime\" attribute in gerrit.config. Please use digits only");
-      throw nfe;  //rethrow so the server stops launching.
-    }
-    return maxLifetime;
+  public int getMaxAuthLifetimeAttr() {
+    return maxAuthLifetimeAttr;
   }
 
   private static String getString(Config cfg, String name) {

--- a/src/main/java/com/thesamet/gerrit/plugins/saml/SamlConfig.java
+++ b/src/main/java/com/thesamet/gerrit/plugins/saml/SamlConfig.java
@@ -32,6 +32,8 @@ public class SamlConfig {
   private final String displayNameAttr;
   private final String userNameAttr;
   private final String emailAddressAttr;
+  private final String maxAuthLifetimeAttr;
+  private final int maxAuthLifetimeDefault = 24 * 60 * 60; // 24h;
 
   @Inject
   SamlConfig(@GerritServerConfig final Config cfg) {
@@ -44,6 +46,8 @@ public class SamlConfig {
     userNameAttr = getGetStringWithDefault(cfg, "userNameAttr", "UserName");
     emailAddressAttr =
         getGetStringWithDefault(cfg, "emailAddressAttr", "EmailAddress");
+    maxAuthLifetimeAttr =
+            getGetStringWithDefault(cfg, "maxAuthLifetime", Integer.toString(maxAuthLifetimeDefault));
   }
 
   public String getMetadataPath() {
@@ -72,6 +76,19 @@ public class SamlConfig {
 
   public String getEmailAddressAttr() {
     return emailAddressAttr;
+  }
+
+  public String getMaxAuthLifetimeAttr() { return maxAuthLifetimeAttr; }
+
+  public int getMaxAuthLifetime() {
+    int maxLifetime;
+    try {
+      maxLifetime = Integer.parseInt(getMaxAuthLifetimeAttr());
+    } catch (NumberFormatException nfe) {
+      SamlWebFilter.logError("Error reading \"maxAuthLifetime\" attribute in gerrit.config. Please use digits only");
+      throw nfe;  //rethrow so the server stops launching.
+    }
+    return maxLifetime;
   }
 
   private static String getString(Config cfg, String name) {

--- a/src/main/java/com/thesamet/gerrit/plugins/saml/SamlWebFilter.java
+++ b/src/main/java/com/thesamet/gerrit/plugins/saml/SamlWebFilter.java
@@ -67,11 +67,11 @@ class SamlWebFilter implements Filter {
     @Inject
     SamlWebFilter(@GerritServerConfig Config gerritConfig, SamlConfig samlConfig) {
         this.samlConfig = samlConfig;
-        log.info("Max Authentication Lifetime: "+ samlConfig.getMaxAuthLifetime());
+        log.debug("Max Authentication Lifetime: " + samlConfig.getMaxAuthLifetimeAttr());
         SAML2ClientConfiguration samlClientConfig = new SAML2ClientConfiguration(
                 samlConfig.getKeystorePath(), samlConfig.getKeystorePassword(),
                 samlConfig.getPrivateKeyPassword(), samlConfig.getMetadataPath());
-        samlClientConfig.setMaximumAuthenticationLifetime(samlConfig.getMaxAuthLifetime());
+        samlClientConfig.setMaximumAuthenticationLifetime(samlConfig.getMaxAuthLifetimeAttr());
         saml2Client =
                 new SAML2Client(samlClientConfig);
         String callbackUrl = gerritConfig.getString("gerrit", null, "canonicalWebUrl") + "plugins/gerrit-saml-plugin/saml";
@@ -265,14 +265,6 @@ class SamlWebFilter implements Filter {
                 return super.getHeader(name);
             }
         }
-    }
-
-    public static void logWarning(String message) {
-        log.warn(message);
-    }
-
-    public static void logError(String message) {
-        log.error(message);
     }
 
     private class AnonymousHttpRequest extends HttpServletRequestWrapper {


### PR DESCRIPTION
maxAuthLifetime = 86400
If no entry included in the gerrit.config the default of
86400 (24 * 60 * 60) is assumed.

This was recently added to the SAML plugin for jenkins to combat
org.pac4j.saml.exceptions.SAMLException:
   Authentication issue instant is too old or in the future
Likewise, this should help with gerrit.

Logs in error_log:
[main] INFO  com.thesamet.gerrit.plugins.saml.SamlWebFilter
    : Max Authentication Lifetime: 86400

Builds against:
 - gerrit-plugin-api version 2.13.6
 - org.pac4j.pac4j-saml version 2.0.0-RC1

Forced change from pac4j-saml update removes RequiresHttpAction
in favor of HTTPAction. Also removes boolean parameter
from saml2Client.redirect(context, true) to saml2Client.redirect(context);