### PR TITLE
Fix maxAuthLifetimeAttr init

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,14 +1,14 @@
 name := "gerrit-saml-plugin"
 
-val GerritVersion = "2.13"
+val GerritVersion = "2.14"
 
-version := GerritVersion + "-6"
+version := GerritVersion + "-2"
 
 javacOptions ++= Seq("-source", "1.7", "-target", "1.7")
 
 libraryDependencies += ("com.google.gerrit" % "gerrit-plugin-api" % GerritVersion % "provided")
 
-libraryDependencies += "org.pac4j" % "pac4j-saml" % "2.0.0-RC1"
+libraryDependencies += "org.pac4j" % "pac4j-saml" % "2.0.0"
 
 libraryDependencies ~= { _ map {
   case m => m

--- a/src/main/java/com/thesamet/gerrit/plugins/saml/SamlConfig.java
+++ b/src/main/java/com/thesamet/gerrit/plugins/saml/SamlConfig.java
@@ -47,7 +47,7 @@ public class SamlConfig {
     userNameAttr = getGetStringWithDefault(cfg, "userNameAttr", "UserName");
     emailAddressAttr =
         getGetStringWithDefault(cfg, "emailAddressAttr", "EmailAddress");
-    maxAuthLifetimeAttr = cfg.getInt("saml", null, maxAuthLifetimeDefault);
+    maxAuthLifetimeAttr = cfg.getInt("saml", "maxAuthLifetime", maxAuthLifetimeDefault);
   }
 
   public String getMetadataPath() {


### PR DESCRIPTION
Plugin can be built, but on start gerrit throwing exception:
  Error injecting constructor, java.lang.NullPointerException
  at com.thesamet.gerrit.plugins.saml.SamlConfig.<init>(SamlConfig.java:40)
  at com.thesamet.gerrit.plugins.saml.SamlConfig.class(SamlConfig.java:37)
  while locating com.thesamet.gerrit.plugins.saml.SamlConfig
    for the 2nd parameter of com.thesamet.gerrit.plugins.saml.SamlWebFilter.<init>(SamlWebFilter.java:68)

So adding variable name to avoid this